### PR TITLE
Add device id override from message

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,25 +10,25 @@ module.exports = function (RED: Red) {
 
         var node = this;
         this.on('input', (msg) => {
-            this.id = config.id;
-            if(this.id != null) {    
+            this.id = msg.id || config.id;
+            if(this.id != null) {
                 this.info("Receieved message for device id " + this.id);
                 blauBergResource.findById(this.id).then(device => {
                     if(device == null) {
                         this.info("Device not found");
                         return;
                     }
-                
+
                     var receivedDevice = msg.payload as Device;
                     device.speed = receivedDevice.speed ?? device.speed;
                     device.mode = receivedDevice.mode ?? device.mode;
                     device.manualSpeed = receivedDevice.manualSpeed ?? device.manualSpeed;
                     device.on = receivedDevice.on ?? device.on;
-                    
+
                     this.info("Sending message to device: " + device);
                     blauBergResource.save(device);
                 });
-                
+
             }
         });
 


### PR DESCRIPTION
Context:
Having multiple devices requires multiple `blauberg-vento` nodes to be created for each ID. Which isn't a problem unless device mapping happens somewhere far from above in the flow. So the message comes with an already attached ID. In that case, we have to route it among separate nodes. That means, **each** ID needs to be duplicated 2 more times - in `switch` and `blauberg-vento` nodes.

![image](https://github.com/michaelkrog/node-red-contrib-blauberg-vento/assets/1101526/6dc1576c-fd1d-413b-a6e6-24121897744f)

The proposed solution makes device ID optionally overridable from the message property so it's easily scalable.
