### PR TITLE
Add device state reading

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,13 @@ module.exports = function (RED: Red) {
                         this.log("Device not found");
                         return;
                     }
+                    if (!msg.payload) {
+                        this.send({
+                            id: this.id,
+                            payload: device,
+                        });
+                        return;
+                    }
 
                     var receivedDevice = msg.payload as Device;
                     device.speed = receivedDevice.speed ?? device.speed;
@@ -26,7 +33,19 @@ module.exports = function (RED: Red) {
                     device.on = receivedDevice.on ?? device.on;
 
                     this.log("Sending message to device: " + device);
-                    blauBergResource.save(device);
+                    blauBergResource.save(device)
+                        .then((updatedDevice) => {
+                            this.send({
+                                id: this.id,
+                                payload: {
+                                    ...device,
+                                    ...updatedDevice
+                                },
+                            });
+                        })
+                        .catch((error) => {
+                            this.error(`Error sending message to device ${device}: ${error}`);
+                        });
                 });
 
             }

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,10 +12,10 @@ module.exports = function (RED: Red) {
         this.on('input', (msg) => {
             this.id = msg.id || config.id;
             if(this.id != null) {
-                this.info("Receieved message for device id " + this.id);
+                this.log("Receieved message for device id " + this.id);
                 blauBergResource.findById(this.id).then(device => {
                     if(device == null) {
-                        this.info("Device not found");
+                        this.log("Device not found");
                         return;
                     }
 
@@ -25,7 +25,7 @@ module.exports = function (RED: Red) {
                     device.manualSpeed = receivedDevice.manualSpeed ?? device.manualSpeed;
                     device.on = receivedDevice.on ?? device.on;
 
-                    this.info("Sending message to device: " + device);
+                    this.log("Sending message to device: " + device);
                     blauBergResource.save(device);
                 });
 
@@ -33,7 +33,7 @@ module.exports = function (RED: Red) {
         });
 
         this.on('editprepare', async _ => {
-            this.info("Listing devices.");
+            this.log("Listing devices.");
             var devices = (await blauBergResource.findAll()).content;
             var el = document.getElementById('node-input-id') as any;
             el.typedInput({


### PR DESCRIPTION
Add an ability to just read the device state without updating it. Useful for device monitoring esp. while it can be updated from a physical remote. This change makes it possible by omitting `payload` property in the message for the existing device node. The updated device state is also being passed through as an output message when updated.

Additionally, fix the `info`=>`log` method call transition which fails in node-red 4.02. Apparently, this was a breaking change but I haven't found an official note on that.